### PR TITLE
Fix for IE8 file attach input

### DIFF
--- a/kinds/file-intruder/kind-file-intruder.styl
+++ b/kinds/file-intruder/kind-file-intruder.styl
@@ -37,7 +37,8 @@ $kind-file-intruder-input
   display: inline-block
   vertical-align: 0
   padding: 0
-  margin: -5em 0 0 -20em
+  margin: -5em 0 0 -400px
+  width: 500px
 
   cursor: pointer
 

--- a/kinds/file-intruder/tests/test_kind-file-intruder.css
+++ b/kinds/file-intruder/tests/test_kind-file-intruder.css
@@ -23,8 +23,9 @@
 
   display: inline-block;
 
+  width: 500px;
   padding: 0;
-  margin: -5em 0 0 -20em;
+  margin: -5em 0 0 -400px;
 
   cursor: pointer;
   vertical-align: 0;


### PR DESCRIPTION
File attach in IE8 didn't work properly properly because of position of file input. Margin left -20em was ignored.
